### PR TITLE
Link to Cart component displays in both logged in and not logged in m…

### DIFF
--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -12,15 +12,24 @@ const Navbar = ({handleClick, isLoggedIn}) => (
         <div>
           {/* The navbar will show these links after you log in */}
           <Link to="/home">Home</Link>
+        </div>
+      ) : (
+        <div>
+          {/* The navbar will show these links before you log in */}
+          <Link to="/allProducts">All Products</Link>
+        </div>
+      )}
+      <div>
+        <Link to="/cart">Cart</Link>
+      </div>
+      {isLoggedIn ? (
+        <div>
           <a href="#" onClick={handleClick}>
             Logout
           </a>
         </div>
       ) : (
         <div>
-          {/* The navbar will show these links before you log in */}
-          <Link to="/allProducts">All Products</Link>
-          <Link to="/cart">Cart</Link>
           <Link to="/login">Login</Link>
           <Link to="/signup">Sign Up</Link>
         </div>

--- a/public/style.css
+++ b/public/style.css
@@ -10,9 +10,14 @@ label {
   display: block;
 }
 
+nav {
+  display: flex;
+}
+
 nav a {
   display: inline-block;
   margin: 1em;
+  flex-direction: row;
 }
 
 form div {


### PR DESCRIPTION
…ode, is second from the left in each, DRY

### Assignee Tasks

* [ x] added unit tests (or none needed)
* [ x] written relevant docs (or none needed)
* [ x] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

_Your PR Notes Here_

altered the navbar so that it shows the link to the Cart component as the second-to-left anchor in both the login and not logged in modes. because this resulted in adjacent divs in the navbar, I made navbar a flexbox in style.css, flex-direction: row