### PR TITLE
travis: activate deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,16 @@ install:
 before_script:
   - psql -c 'create database "stacks-fifth-test";' -U postgres # remember to change this name if you change it elsewhere (e.g. package.json)
 script:
-  - npm test             # test the code
+  - npm test # test the code
   - npm run build-client # make the bundle
-
-# before_deploy:
-#   - rm -rf node_modules # omit from the tarball, since we skip cleanup
-# deploy:
-#   skip_cleanup: true # prevents travis from deleting the build
-#   provider: heroku
-#   app: YOUR-HEROKU-APP-NAME-HERE # see README
-#   api_key:
-#     secure: YOUR-***ENCRYPTED***-API-KEY-HERE # see README
+before_deploy: # omit node_modules, since we set skip_cleanup below
+  - rm -rf node_modules
+deploy: # see README for details on these keys
+  # prevents travis from deleting the build
+  skip_cleanup: true
+  provider: heroku
+  # app should be your heroku app name; see README
+  app: stacksfifth
+  # the secure key indicates an encrypted value; see README
+  api_key:
+    secure: LDteT+QPgkgHk4FHAb71Uq/zaO8T05QKZSjj4kfDJqaSrOUm0sj4YZs1nXXVU1jyS+w+4dpwA5Q2XZQZJUQ0aSrB8tr3Dk2p0fwR+V87RyE68sh9YPP2OCYFUH2uHBdf6ZMguslZ4BYfsx0fBLDDykXWzrjGDdETYwnvXv5AJOLQBI1zlzvaISAvlS7Ritf2a4rF5EwlEgopKzZnieLL3TIhSe5QvXd9C+idAEbdvIGEUVwujVVIwJHHpZvc4VlvSnI1ScU7Nlb/2UwIChdEOGIK2+LciX/b1dBIoTtrTorfqP/FuEpvFCcv6YJfpjD9GEKn80eyzP1RRWeozdUF7uZ1utVrM9fHusmRNp0+mKlNw6IrsSm+NAOQ2L2O0PM9mcTr2zsDO/d2PyAPlwO66YVS2aqTYDshIV3chnTWs2ncu9qD8+WZ2gbrV3JQTOfnzFGX8ona7shVTt1FvejIDgc0Q4sR66dYLuzftlV51Qts/BI3pNH2xjTMY+wRjRiki1j2EU43ZJYN9nCcdxBMCwnUAMlUrmq1/Yr01mYTEdINoxKYtm5/qnbD/3uE14GcZ19uQAuJoK6Yu0vGSl+INKKWkGPFYtdsj1Nlb1zmY/WB81lv/Psq0sRepyTM05QPObHa707+G5SY1fjpeNooKVCyw+GBA2YYElSc+0gz7V0=


### PR DESCRIPTION
This pull request should allow travis to automate deployment with each pull request. I followed the directions in the original readme to properly set this up. Travis was working, that is, it was running the tests and seeing if it passes. But, it was not deploying because the travis.yml file had the deploy code commented out. It is now commented in with everything filled out as required. 